### PR TITLE
add some documentation to clarify this is not actually picoprobe

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,33 +2,33 @@ cmake_minimum_required(VERSION 3.12)
 
 include(pico_sdk_import.cmake)
 
-project(picoprobe)
+project(ox64-uart)
 
 pico_sdk_init()
 
-add_executable(picoprobe
+add_executable(ox64-uart
         src/main.c
         src/usb_descriptors.c
         src/cdc_uart.c
         src/get_serial.c
 )
 
-target_compile_options(picoprobe PRIVATE -Wall)
+target_compile_options(ox64-uart PRIVATE -Wall)
 
 if (DEFINED ENV{PICOPROBE_LED})
         message("PICOPROBE_LED is defined as " $ENV{PICOPROBE_LED})
-        target_compile_definitions(picoprobe PRIVATE PICOPROBE_LED=$ENV{PICOPROBE_LED})
+        target_compile_definitions(ox64-uart PRIVATE PICOPROBE_LED=$ENV{PICOPROBE_LED})
 endif()
 
 set(DBG_PIN_COUNT=4)
 
-target_include_directories(picoprobe PRIVATE src)
+target_include_directories(ox64-uart PRIVATE src)
 
-target_compile_definitions (picoprobe PRIVATE
+target_compile_definitions (ox64-uart PRIVATE
 	PICO_RP2040_USB_DEVICE_ENUMERATION_FIX=1
 )
 
-target_link_libraries(picoprobe PRIVATE
+target_link_libraries(ox64-uart PRIVATE
         pico_multicore
         pico_stdlib
         pico_unique_id
@@ -36,6 +36,6 @@ target_link_libraries(picoprobe PRIVATE
         tinyusb_board
 )
 
-pico_set_binary_type(picoprobe copy_to_ram)
+pico_set_binary_type(ox64-uart copy_to_ram)
 
-pico_add_extra_outputs(picoprobe)
+pico_add_extra_outputs(ox64-uart)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# Picoprobe
-Picoprobe allows a Pico / RP2040 to be used as USB -> SWD and UART bridge. This means it can be used as a debugger and serial console for another Pico.
+# Ox64-uart
+Ox64-uart allows a Pico / RP2040 to be used as two UART bridges. By default these are set so that UART0 tx is on GPIO4, UART0 rx is on GPIO5, UART1 tx is on GPIO12, and UART1 rx is on GPIO13.  These can be changed by modifying picoprobe_config.h and re-building.
 
-# Documentation
-Picoprobe documentation can be found in the [Pico Getting Started Guide](https://datasheets.raspberrypi.com/pico/getting-started-with-pico.pdf). See "Appendix A: Using Picoprobe".
+
+Ox64-uart is derived from [Picoprobe](https://github.com/raspberrypi/picoprobe), which has documentation  in the [Pico Getting Started Guide](https://datasheets.raspberrypi.com/pico/getting-started-with-pico.pdf). See "Appendix A: Using Picoprobe".

--- a/src/usb_descriptors.c
+++ b/src/usb_descriptors.c
@@ -108,11 +108,11 @@ char const* string_desc_arr [] =
 {
   (const char[]) { 0x09, 0x04 }, // 0: is supported language is English (0x0409)
   "Raspberry Pi", // 1: Manufacturer
-  "Picoprobe CMSIS-DAP", // 2: Product
+  "ox64-uart CMSIS-DAP", // 2: Product
   usb_serial,     // 3: Serial, uses flash unique ID
-  "Picoprobe CMSIS-DAP v1", // 4: Interface descriptor for HID transport
-  "Picoprobe CMSIS-DAP v2", // 5: Interface descriptor for Bulk transport
-  "Picoprobe CDC-ACM UART", // 6: Interface descriptor for CDC
+  "ox64-uart CMSIS-DAP v1", // 4: Interface descriptor for HID transport
+  "ox64-uart CMSIS-DAP v2", // 5: Interface descriptor for Bulk transport
+  "ox64-uart CDC-ACM UART", // 6: Interface descriptor for CDC
 };
 
 static uint16_t _desc_str[32];


### PR DESCRIPTION
Just what it says on the tin - I got here from trying to flash an ox64 but I was already familiar with picoprobe and it took me some time to figure out that this is *derived from* picoprobe but has a different purpose.  This PR just does some renaming and README cleanup to help that be clearer.